### PR TITLE
support musl for sysconf(_SC_GETPW_R_SIZE_MAX)

### DIFF
--- a/user_mgr.cpp
+++ b/user_mgr.cpp
@@ -888,7 +888,7 @@ bool UserMgr::userPasswordExpired(const std::string& userName)
     {};
     struct spwd* spwdPtr = nullptr;
     auto buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
-    if (buflen < -1)
+    if (buflen < 1)
     {
         // Use a default size if there is no hard limit suggested by sysconf()
         buflen = 1024;


### PR DESCRIPTION
In user_mgr.cpp, specifically in the UserMgr::userPasswordExpired function, the exception handling for sysconf(_SC_GETPW_R_SIZE_MAX) may not be appropriate.

In glibc, when an error occurs, sysconf(_SC_GETPW_R_SIZE_MAX) returns -1. More importantly, in musl, this function will also only return -1. This can lead to issues with std::vector<char> buffer(buflen).

Therefore, changing the condition from if (buflen < -1) to if (buflen < 1) would be more suitable.